### PR TITLE
Update tools page content

### DIFF
--- a/docs/get-started/tools.md
+++ b/docs/get-started/tools.md
@@ -2,6 +2,8 @@
 
 ## Git
 
+Teams use [Git](https://git-scm.com/) as a distributed VCS. You can interact with Git via the CLI or using any of [several GUI clients](https://git-scm.com/downloads/guis), some of which are available via Self Service.
+
 ## IDE
 
 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Visual_Studio_Code_1.35_icon.svg/150px-Visual_Studio_Code_1.35_icon.svg.png" alt="VSCode logo" title="VSCode" width="160" align="right">
@@ -26,8 +28,14 @@ Some IDEs have terminal built in which leverage the CLI of the OS.
 
 ## Homebrew
 
+[Homebrew](https://brew.sh/) is a package manager for macOS that aims to simplify the installation of software and tolls that are not included by default. 
+
 ## Terraform
 
+[Terraform](https://developer.hashicorp.com/terraform) is an infrastructure as code tool that lets you build, change, and version resources safely and efficiently.
+
 ## AWS CLI
+
+The AWS CLI is a unified tool to manage and control AWS services from the command line.
 
 ## Tunnelblick


### PR DESCRIPTION
## What

This PR proposes introducing a small amount of descriptive content under the existing headings for Git, Homebrew and AWS CLI in the [tools page](https://nationalarchives.github.io/engineering-handbook/get-started/tools/) of "Getting started"

## Why

While working through the page during onboarding, I noticed the sections weren't populated, and I felt confident enough to provide a bit of descriptive content. I'm not too familiar with others listed on the page, so have left those as they are. 